### PR TITLE
SM-6049: Use latest data hash with new event enum values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3378,8 +3378,8 @@
       }
     },
     "street-manager-data": {
-      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#645188067f1c233006d8e9790f6d18cf18c8e39e",
-      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#645188067f1c233006d8e9790f6d18cf18c8e39e",
+      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#fc67add4b743d3176670337ae15da84e55809e60",
+      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#fc67add4b743d3176670337ae15da84e55809e60",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "knex": "^0.14.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "inversify": "^5.0.1",
     "moment-timezone": "^0.5.31",
     "reflect-metadata": "^0.1.13",
-    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#645188067f1c233006d8e9790f6d18cf18c8e39e"
+    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#fc67add4b743d3176670337ae15da84e55809e60"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.51",


### PR DESCRIPTION
## Description

Data - https://github.com/departmentfortransport/street-manager-data/pull/103
API - https://github.com/departmentfortransport/street-manager-api/pull/881
Stable API - https://github.com/departmentfortransport/street-manager-api-stable/pull/24
Event notifier - https://github.com/departmentfortransport/street-manager-event-notifier/pull/26
Event subscriber - https://github.com/departmentfortransport/street-manager-event-subscriber/pull/10

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] All unit tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Significant events are being logged e.g. error scenarios
- [ ] Commit messages are meaningful
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-event-subscriber/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
